### PR TITLE
Encode recipe filter queries, fix Cuisine label and serving tag formatting

### DIFF
--- a/src/components/createEdit/createSingleContainer/CreateSingleContainer.vue
+++ b/src/components/createEdit/createSingleContainer/CreateSingleContainer.vue
@@ -10,6 +10,7 @@ import {
   IonItem,
   IonCard,
   IonCardContent,
+  IonButton,
   IonTextarea,
 } from "@ionic/vue";
 
@@ -43,7 +44,7 @@ const {
         </ion-item>
         <ion-item>
           <ion-input
-            label="Cusine(s)"
+            label="Cuisine(s)"
             label-placement="stacked"
             v-model="cuisinesString"
           />
@@ -90,7 +91,7 @@ const {
             label="Instructions"
             label-placement="stacked"
             v-model="instructionsString"
-          />s
+          />
         </ion-item>
       </ion-list>
     </ion-card-content>

--- a/src/services/apiService.ts
+++ b/src/services/apiService.ts
@@ -75,23 +75,20 @@ export const fetchRecipes = async (
   courses: string[],
   tags: string[],
 ): Promise<ApiResult<Recipe[]>> => {
-  let url = BACKEND_BASE + "/recipe?";
+  const params = new URLSearchParams();
 
   if (name) {
-    url += `name=${name}&`;
+    params.set("name", name);
   }
 
-  if (courses.length) {
-    courses.forEach((c: string) => (url += `course=${c}&`));
-  }
+  courses.forEach((course: string) => params.append("course", course));
+  cuisines.forEach((cuisine: string) => params.append("cuisine", cuisine));
+  tags.forEach((tag: string) => params.append("tag", tag));
 
-  if (cuisines.length) {
-    cuisines.forEach((c: string) => (url += `cuisine=${c}&`));
-  }
-
-  if (tags.length) {
-    tags.forEach((t: string) => (url += `tag=${t}&`));
-  }
+  const query = params.toString();
+  const url = query
+    ? `${BACKEND_BASE}/recipe?${query}`
+    : `${BACKEND_BASE}/recipe`;
 
   const result = await get<Array<Recipe & { uploaded: string | null }>>(url);
   if (!result.ok) {

--- a/src/services/recipeService.ts
+++ b/src/services/recipeService.ts
@@ -38,11 +38,20 @@ export const useRecipeService = (
   };
 
   const formattedServingTag: ComputedRef<string> = computed(() => {
-    return `${recipe.value?.servingAmount} ${recipe.value?.servingName}`;
+    if (!recipe.value) {
+      return "";
+    }
+
+    const { servingAmount, servingName } = recipe.value;
+    if (servingAmount === undefined || servingName === undefined) {
+      return "";
+    }
+
+    return `${servingAmount} ${servingName}`.trim();
   });
 
   const formattedCuisineTag: ComputedRef<string | boolean> = computed(() =>
-    formatTag("Cusine", recipe.value?.cuisineTypes),
+    formatTag("Cuisine", recipe.value?.cuisineTypes),
   );
 
   const formattedCourseTag: ComputedRef<string | boolean> = computed(() =>


### PR DESCRIPTION
### Motivation
- Prevent malformed query strings when fetching recipes with names/tags that include special characters by using a proper query builder.
- Avoid showing `undefined`/garbled serving information in the UI when recipe data is missing or incomplete.
- Correct UX copy and stray markup in the create-single recipe form so labels render correctly and the Add button works.

### Description
- Replace manual string concatenation with `URLSearchParams` in `fetchRecipes` to encode query parameters and produce either `${BACKEND_BASE}/recipe` or `${BACKEND_BASE}/recipe?${query}` as appropriate (`src/services/apiService.ts`).
- Guard `formattedServingTag` against missing `recipe.value` and missing fields and `trim()` the result, and fix the `Cuisine` spelling passed to `formatTag` (`src/services/recipeService.ts`).
- Import `IonButton`, fix the `Cuisine(s)` label, and remove a stray character after the `instructions` textarea in the create-single form (`src/components/createEdit/createSingleContainer/CreateSingleContainer.vue`).

### Testing
- Started the dev server with `npm run dev:container`, which reported successful startup and served the app (succeeded).
- Ran a Playwright script that navigated to `/recipe/create/single` and captured a screenshot of the form (succeeded).
- Unit tests (`vitest`) were not run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69683e19e31c832b8c2d96537ab9a361)