### PR TITLE
Update unit tests for the PrimeVue migration

### DIFF
--- a/tests/unit/components/browse/filterMenu/filterMenuService.spec.ts
+++ b/tests/unit/components/browse/filterMenu/filterMenuService.spec.ts
@@ -42,8 +42,8 @@ describe("filterMenuService", () => {
   it("Can add filter chip to course", () => {
     const { service } = setup();
 
-    service.setFilterText("New Value");
-    service.setCurrentFilterType(FilterType.COURSE);
+    service.filterText.value = "New Value";
+    service.currentFilterType.value = FilterType.COURSE;
 
     service.addFilter();
 
@@ -53,8 +53,8 @@ describe("filterMenuService", () => {
   it("Can add filter chip to cuisine", () => {
     const { service } = setup();
 
-    service.setFilterText("New Value");
-    service.setCurrentFilterType(FilterType.CUISINE);
+    service.filterText.value = "New Value";
+    service.currentFilterType.value = FilterType.CUISINE;
 
     service.addFilter();
 
@@ -64,8 +64,8 @@ describe("filterMenuService", () => {
   it("Can add filter chip to tag", () => {
     const { service } = setup();
 
-    service.setFilterText("New Value");
-    service.setCurrentFilterType(FilterType.TAG);
+    service.filterText.value = "New Value";
+    service.currentFilterType.value = FilterType.TAG;
 
     service.addFilter();
 

--- a/tests/unit/components/common/ingredientCard/ingredientCardService.spec.ts
+++ b/tests/unit/components/common/ingredientCard/ingredientCardService.spec.ts
@@ -8,9 +8,6 @@ import { generateIngredient } from "@tests/data/defaults";
 import { Ingredient } from "@/types/Ingredient";
 
 vi.mock("@/services/apiService");
-vi.mock("@/composables/usePageRefresher", () => ({
-  usePageRefresher: () => {},
-}));
 
 interface SetupOptions {
   recipeId?: number;

--- a/tests/unit/components/common/instructionCard/instructionCardService.spec.ts
+++ b/tests/unit/components/common/instructionCard/instructionCardService.spec.ts
@@ -1,14 +1,10 @@
 import { describe, it, expect, vi, Mock } from "vitest";
 
 vi.mock("@/services/apiService");
-vi.mock("@/composables/usePageRefresher", () => ({
-  usePageRefresher: () => {},
-}));
 
 import {
   InstructionCardService,
   useInstructionCardService,
-  formatInstruction,
 } from "@/components/viewRecipe/instructionCard/instructionCardService";
 import { ApiResult, fetchInstructions } from "@/services/apiService";
 
@@ -60,9 +56,5 @@ describe("instructionCardService", () => {
     await vi.waitFor(() => expect(service.isLoading.value).toBe(false));
 
     expect(service.instructions.value).toEqual(instructions);
-  });
-
-  it("formats instruction", () => {
-    expect(formatInstruction(100, "instruction")).toEqual("100: instruction");
   });
 });

--- a/tests/unit/components/createEdit/createSingleContainerService.spec.ts
+++ b/tests/unit/components/createEdit/createSingleContainerService.spec.ts
@@ -66,7 +66,7 @@ describe("createSingleContainerService", () => {
     service.servingAmount.value = 4;
     service.servingName.value = "plates";
     service.sourceUrl.value = "https://example.com";
-    service.ingredientsString.value = "2,cups,Rice,washed\nSugar,Sweet";
+    service.ingredientsString.value = "2|cups|Rice|washed\nSugar|Sweet";
     service.instructionsString.value = "Mix thoroughly\nServe warm";
 
     await service.add();

--- a/tests/unit/components/createEdit/editHeaderContainer/editHeaderContainerService.spec.ts
+++ b/tests/unit/components/createEdit/editHeaderContainer/editHeaderContainerService.spec.ts
@@ -1,9 +1,6 @@
 import { describe, it, expect, vi, Mock } from "vitest";
 
 vi.mock("@/services/apiService");
-vi.mock("@/composables/usePageRefresher", () => ({
-  usePageRefresher: () => {},
-}));
 
 import {
   useEditHeaderContainerService,

--- a/tests/unit/components/createEdit/editIngredientsService.spec.ts
+++ b/tests/unit/components/createEdit/editIngredientsService.spec.ts
@@ -14,9 +14,6 @@ import { IngredientList } from "@/types/IngredientList";
 
 vi.mock("@/services/apiService");
 vi.mock("vue-router");
-vi.mock("@/composables/usePageRefresher", () => ({
-  usePageRefresher: () => {},
-}));
 
 const recipeId = 10;
 const testName = "Test Ingredient";
@@ -62,7 +59,7 @@ describe("editIngredientsService", () => {
     const { service, routerGo } = setup();
     await vi.waitFor(() => expect(service.ingredients.value.length).toBe(1));
 
-    service.onSaveClick();
+    await service.onSaveClick();
 
     expect(saveIngredients as Mock).toHaveBeenCalledWith({
       recipeId,

--- a/tests/unit/components/createEdit/editInstructionsService.spec.ts
+++ b/tests/unit/components/createEdit/editInstructionsService.spec.ts
@@ -12,9 +12,6 @@ import { useRouter } from "vue-router";
 
 vi.mock("@/services/apiService");
 vi.mock("vue-router");
-vi.mock("@/composables/usePageRefresher", () => ({
-  usePageRefresher: () => {},
-}));
 
 const defaultInstructionsResponse = {
   recipeId: 5,
@@ -59,7 +56,7 @@ describe("editInstructionsService", () => {
     const { service, routerGo } = setup();
     await vi.waitFor(() => expect(service.instructions.value.length).toBe(2));
 
-    service.onSaveClick();
+    await service.onSaveClick();
 
     expect(saveInstructions as Mock).toHaveBeenCalledWith({
       recipeId: defaultInstructionsResponse.recipeId,

--- a/tests/unit/components/viewRecipe/viewRecipeContainer/viewRecipeContainerService.spec.ts
+++ b/tests/unit/components/viewRecipe/viewRecipeContainer/viewRecipeContainerService.spec.ts
@@ -2,9 +2,6 @@ import { describe, it, expect, vi, Mock, beforeEach } from "vitest";
 
 vi.mock("@/services/apiService");
 vi.mock("vue-router");
-vi.mock("@/composables/usePageRefresher", () => ({
-  usePageRefresher: () => {},
-}));
 
 import {
   useViewRecipeContainerService,

--- a/tests/unit/services/apiService.spec.ts
+++ b/tests/unit/services/apiService.spec.ts
@@ -63,7 +63,7 @@ describe("apiService", () => {
     );
 
     expect(axiosMock.get).toHaveBeenCalledWith(
-      "http://example.com/recipe?name=Test Name&course=Course 1&course=Course 2&cuisine=Cuisine 1&tag=Tag 1&",
+      "http://example.com/recipe?name=Test+Name&course=Course+1&course=Course+2&cuisine=Cuisine+1&tag=Tag+1",
     );
     expect(result).toEqual({ ok: true, data });
   });

--- a/tests/unit/services/recipeService.spec.ts
+++ b/tests/unit/services/recipeService.spec.ts
@@ -33,7 +33,7 @@ describe("useRecipeService.ts", () => {
   it("formats one cuisine", () => {
     const recipe: Recipe = generateRecipe({ cuisineTypes: ["Test Cuisine"] });
     const { service } = setup({ recipe });
-    expect(service.formattedCuisineTag.value).toBe("Cusine: Test Cuisine");
+    expect(service.formattedCuisineTag.value).toBe("Cuisine: Test Cuisine");
   });
 
   it("formats multipe cuisines", () => {
@@ -42,7 +42,7 @@ describe("useRecipeService.ts", () => {
     });
     const { service } = setup({ recipe });
     expect(service.formattedCuisineTag.value).toBe(
-      "Cusines: Test Cuisine 1, Test Cuisine 2",
+      "Cuisines: Test Cuisine 1, Test Cuisine 2",
     );
   });
 

--- a/tests/unit/views/browseView/browseViewService.spec.ts
+++ b/tests/unit/views/browseView/browseViewService.spec.ts
@@ -2,9 +2,6 @@ import { vi, describe, it, expect, Mock } from "vitest";
 
 vi.mock("@/services/apiService");
 vi.mock("vue-router");
-vi.mock("@/composables/usePageRefresher", () => ({
-  usePageRefresher: () => {},
-}));
 
 import { ApiResult, fetchRecipes } from "@/services/apiService";
 import { useRoute, useRouter } from "vue-router";


### PR DESCRIPTION
The PrimeVue/Tailwind migration changed several service APIs, but the unit tests were never updated. 10 tests across 7 files were failing on `primevue-migrate`.

**Test files only — `git diff src/` is empty.** The source is treated as the source of truth throughout.

## Fixes

| Test | Cause |
| --- | --- |
| `apiService` | `fetchRecipes` now builds its query with `URLSearchParams` — spaces encode as `+`, no trailing `&` |
| `recipeService` ×2 | Expectations misspelled `"Cusine"` / `"Cusines"`; the code was always right |
| `createSingleContainer` | Service splits ingredient lines on `\|`, test fed commas — fixed the input fixture, left the expectation |
| `filterMenu` ×3 | `setFilterText` / `setCurrentFilterType` replaced by writable refs; tests now assign `.value` directly |
| `editIngredients`, `editInstructions` | `onSaveClick` became `async`; assertions ran before the promise settled |
| `instructionCard` | **Test deleted.** `formatInstruction` was removed in `dde9d15`; step numbering is now an `<ol class="list-decimal">` in the template, so there is no service behavior left to test |

Also drops dead `vi.mock("@/composables/usePageRefresher", …)` blocks from four already-passing files. That composable was deleted during the migration and nothing in `src/` references it.

## Result

```
Test Files  17 passed (17)
     Tests  68 passed (68)
```

## Known issues, deliberately not addressed here

Out of scope for a test-only change, but worth tracking:

1. `createSingleContainerService.ts:45` — `"".split(",")` returns `[""]`, so an empty courses/cuisines/tags field posts `[""]` instead of `[]`. No test covers it.
2. `npx vue-tsc --noEmit` fails on `src/style/theme.ts` with `Cannot find module '@primeuix/themes/aura'`. The package is installed; `moduleResolution: "Node"` doesn't read its `exports` map. Vite resolves it fine, so only `npm run build` is affected. Pre-existing.
3. `EditIngredientsService.onSaveClick` / `EditInstructionsService.onSaveClick` are typed `() => void` but implemented `async`, hiding the promise from callers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)